### PR TITLE
Add vanilla mission for unmodded DayZ 0.44

### DIFF
--- a/dayzea.ChernarusPlus/description.ext
+++ b/dayzea.ChernarusPlus/description.ext
@@ -1,0 +1,22 @@
+respawn = "BASE";
+respawndelay = 5;
+onLoadMission="DayZ: lets roll";
+OnLoadIntro = "BANGARANG!";
+OnLoadIntroTime = false;
+OnLoadMissionTime = false;
+destroyDisconnected = false;
+
+// roleless missions
+scriptedPlayer = true;//???
+
+disableChannels[]={0,1,2,6};
+
+class Header
+{
+ gameType = COOP;            //DM, Team, Coop, ...
+ minPlayers = 1;             //min # of players the mission supports
+ maxPlayers = 20;            //Max # of players the mission supports
+};
+
+//#include "dialogs\baseClasses.hpp"
+//#include "dialogs\DZ_CharacterCreation.hpp"

--- a/dayzea.ChernarusPlus/init.sqf
+++ b/dayzea.ChernarusPlus/init.sqf
@@ -1,0 +1,25 @@
+setTimeForScripts 90;
+
+call compile preprocessFileLineNumbers "\dz\modulesDayZ\init.sqf";
+
+DZ_MP_CONNECT = true;
+DZ_MAX_ZOMBIES = 700;
+
+
+call dbLoadPlayer;
+dbSelectHost "http://localhost/DayZServlet/"; 
+
+
+_humidity = 0.3;
+//setDate getSystemTime;
+simulSetHumidity _humidity;
+0 setOvercast _humidity;
+
+_position = [7500,7500,0];
+exportProxies [_position,200000];
+call init_spawnZombies;
+sleep 1;
+importProxies;	
+spawnLoot [_position,15000,25000];
+
+setTimeForScripts 0.03;

--- a/dayzea.ChernarusPlus/mission.biedi
+++ b/dayzea.ChernarusPlus/mission.biedi
@@ -1,0 +1,14 @@
+class prefix_0
+{
+	objectType="prefix";
+	class Arguments
+	{
+	};
+};
+class postfix_0
+{
+	objectType="postfix";
+	class Arguments
+	{
+	};
+};

--- a/dayzea.ChernarusPlus/mission.sqf
+++ b/dayzea.ChernarusPlus/mission.sqf
@@ -1,0 +1,5 @@
+activateAddons [
+];
+
+activateAddons [];
+


### PR DESCRIPTION
This adds a vanilla mission that can be reverted to in the case of any issues. I should be able to restore the original versions of server_data and modules_DayZ since these scripts are completely overridden in the DayZ Legacy mod file. This means I can essentially switch between "stock" and "legacy" DayZ with all of my changes. 